### PR TITLE
Refactor common.

### DIFF
--- a/common.go
+++ b/common.go
@@ -124,34 +124,15 @@ type Clouds struct {
 // ValidDataUnit makes sure the string passed in is an accepted
 // unit of measure to be used for the return data.
 func ValidDataUnit(u string) bool {
-	for d := range DataUnits {
-		if u == d {
-			return true
-		}
-	}
-	return false
+	_, ok := DataUnits[u]
+	return ok
 }
 
 // ValidLangValue makes sure the string passed in is an
 // acceptable lang code.
 func ValidLangCode(c string) bool {
-	for d, _ := range LangCodes {
-		if c == d {
-			return true
-		}
-	}
-	return false
-}
-
-// ValidDataUnitSymbol makes sure the string passed in is an
-// acceptable data unit symbol.
-func ValidDataUnitSymbol(u string) bool {
-	for _, d := range DataUnits {
-		if u == d {
-			return true
-		}
-	}
-	return false
+	_, ok := LangCodes[c]
+	return ok
 }
 
 // CheckAPIKeyExists will see if an API key has been set.

--- a/common_test.go
+++ b/common_test.go
@@ -31,17 +31,6 @@ func TestValidDataUnit(t *testing.T) {
 	}
 }
 
-func TestDataUnitValues(t *testing.T) {
-	for _, s := range DataUnits {
-		if !ValidDataUnitSymbol(s) {
-			t.Error("False positive on data unit symbol")
-		}
-	}
-	if ValidDataUnitSymbol("X") {
-		t.Error("Invalid data unit symbol")
-	}
-}
-
 func TestCheckAPIKeyExists(t *testing.T) {
 	c := &Config{
 		APIKey: "asdf1234",


### PR DESCRIPTION
Openweathermap should use the "comma ok" idiom described [here](https://golang.org/doc/effective_go.html#maps) when checking for the existence of a key in a map. Rids us of some iteration. :)

Also removed the redundant ValidDataUnitSymbol function and accompanying test, as it is doing the same thing as ValidDataUnit. Or did I overlook something? Alhough obviously that's a breaking change, not sure if you are "v1" yet. :)