### PR TITLE
Make golint (mostly) happy.

### DIFF
--- a/common.go
+++ b/common.go
@@ -132,10 +132,10 @@ func ValidDataUnit(u string) bool {
 	return false
 }
 
-// ValidLangValue makes sure the string passed in is an
+// ValidLangCode makes sure the string passed in is an
 // acceptable lang code.
 func ValidLangCode(c string) bool {
-	for d, _ := range LangCodes {
+	for d := range LangCodes {
 		if c == d {
 			return true
 		}

--- a/common_test.go
+++ b/common_test.go
@@ -21,7 +21,7 @@ import (
 // TestValidDataUnit tests whether or not ValidDataUnit provides
 // the correct assertion on provided data unit.
 func TestValidDataUnit(t *testing.T) {
-	for u, _ := range DataUnits {
+	for u := range DataUnits {
 		if !ValidDataUnit(u) {
 			t.Error("False positive on data unit")
 		}

--- a/current.go
+++ b/current.go
@@ -59,7 +59,7 @@ func NewCurrent(unit, lang string) (*CurrentWeatherData, error) {
 	return c, nil
 }
 
-// Set the language responses will be displayed as.  This isn't part of the
+// SetLang allows you to set the language responses will be displayed as.  This isn't part of the
 // NewCurrent call because it'd keep it easier to go with API defaults and
 // adjust if explicitly called.
 func (w *CurrentWeatherData) SetLang(lang string) error {

--- a/current_test.go
+++ b/current_test.go
@@ -22,7 +22,7 @@ import (
 // TestNewCurrent will verify that a new instance of CurrentWeatherData is created
 func TestNewCurrent(t *testing.T) {
 	t.Parallel()
-	for d, _ := range DataUnits {
+	for d := range DataUnits {
 		t.Logf("Data unit: %s", d)
 		if ValidDataUnit(d) {
 			c, err := NewCurrent(d, "en")

--- a/forecast_test.go
+++ b/forecast_test.go
@@ -24,7 +24,7 @@ var forecastRange = []int{3, 7, 10}
 // TestNewForecast will make sure the a new instance of Forecast is returned
 func TestNewForecast(t *testing.T) {
 	t.Parallel()
-	for d, _ := range DataUnits {
+	for d := range DataUnits {
 		t.Logf("Data unit: %s", d)
 		if ValidDataUnit(d) {
 			c, err := NewForecast(d, "ru")

--- a/history_test.go
+++ b/history_test.go
@@ -22,7 +22,7 @@ import (
 // TestNewHistory verifies NewHistorical does as advertised
 func TestNewHistory(t *testing.T) {
 	t.Parallel()
-	for d, _ := range DataUnits {
+	for d := range DataUnits {
 		t.Logf("Data unit: %s", d)
 		if ValidDataUnit(d) {
 			c, err := NewHistorical(d)

--- a/station.go
+++ b/station.go
@@ -54,7 +54,7 @@ func ValidateStationDataParameter(param string) bool {
 	return false
 }
 
-// convertToURLValues will convert a map to a url.Values instance. We're
+// ConvertToURLValues will convert a map to a url.Values instance. We're
 // taking a map[string]string instead of something more type specific since
 // the url.Values instance only takes strings to create the URL values.
 func ConvertToURLValues(data map[string]string) string {


### PR DESCRIPTION
Running "golint ." (https://github.com/golang/lint) inside the openweathermap directory returns a bunch of advice:

```
_examples/cli/weather.go:44:7: exported const URL should have comment or be unexported
_examples/web/weatherweb.go:20:7: exported const URL should have comment or be unexported
common.go:20:5: exported var DataUnits should have comment or be unexported
common.go:135:1: comment on exported function ValidLangCode should be of the form "ValidLangCode ..."
common.go:114:2: don't use underscores in Go names; struct field Sea_level should be SeaLevel
common.go:115:2: don't use underscores in Go names; struct field Grnd_level should be GrndLevel
common.go:138:9: should omit 2nd value from range; this loop is equivalent to `for d := range ...`
common_test.go:24:9: should omit 2nd value from range; this loop is equivalent to `for u := range ...`
current.go:62:1: comment on exported method CurrentWeatherData.SetLang should be of the form "SetLang ..."
current_test.go:25:9: should omit 2nd value from range; this loop is equivalent to `for d := range ...`
forecast_test.go:27:9: should omit 2nd value from range; this loop is equivalent to `for d := range ...`
history.go:34:6: exported type Rain should have comment or be unexported
history_test.go:25:9: should omit 2nd value from range; this loop is equivalent to `for d := range ...`
station.go:57:1: comment on exported function ConvertToURLValues should be of the form "ConvertToURLValues ..."
```

I've gone through and corrected all but a few, where either I wasn't sure how to comment them, or changing them would result in breaking the API. Just FYI, these are:

```
_examples/cli/weather.go:44:7: exported const URL should have comment or be unexported
_examples/web/weatherweb.go:20:7: exported const URL should have comment or be unexported
common.go:20:5: exported var DataUnits should have comment or be unexported
common.go:114:2: don't use underscores in Go names; struct field Sea_level should be SeaLevel
common.go:115:2: don't use underscores in Go names; struct field Grnd_level should be GrndLevel
history.go:34:6: exported type Rain should have comment or be unexported
```