### PR TITLE
Add support for rain and snow in current weathr conditions

### DIFF
--- a/current.go
+++ b/current.go
@@ -25,17 +25,19 @@ import (
 // CurrentWeatherData struct contains an aggregate view of the structs
 // defined above for JSON to be unmarshaled into.
 type CurrentWeatherData struct {
-	GeoPos  Coordinates `json:"coord"`
-	Sys     Sys         `json:"sys"`
-	Base    string      `json:"base"`
-	Weather []Weather   `json:"weather"`
-	Main    Main        `json:"main"`
-	Wind    Wind        `json:"wind"`
-	Clouds  Clouds      `json:"clouds"`
-	Dt      int         `json:"dt"`
-	ID      int         `json:"id"`
-	Name    string      `json:"name"`
-	Cod     int         `json:"cod"`
+	GeoPos  Coordinates        `json:"coord"`
+	Sys     Sys                `json:"sys"`
+	Base    string             `json:"base"`
+	Weather []Weather          `json:"weather"`
+	Main    Main               `json:"main"`
+	Wind    Wind               `json:"wind"`
+	Clouds  Clouds             `json:"clouds"`
+	Rain    map[string]float64 `json:"rain"`
+	Snow    map[string]float64 `json:"snow"`
+	Dt      int                `json:"dt"`
+	ID      int                `json:"id"`
+	Name    string             `json:"name"`
+	Cod     int                `json:"cod"`
 	Unit    string
 	Lang    string
 	Key     string


### PR DESCRIPTION
Adressing issue #32 

I've added fields for snow and rain for current weather API. Since API itself seems to be inconsistent in terms over which period it provides precipitation amount (doc example shows 3h, I've seen 1h in real life), I used a map to store them.