### PR TITLE
New feature: configure http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,26 @@ func main() {
 }
 ```
 
+### Initiate with custom http client
+
+```Go
+func main() {
+    client = &http.Client{}
+    w, err := owm.NewCurrent("F", "EN", owm.WithHttpClient(client))
+    if err != nil {
+        log.Fatalln(err)
+    }
+}
+```
+
 ### Current UV conditions
 
 ```Go
 func main() {
-    uv := NewUV()
+    uv, err := NewUV()
+    if err != nil {
+        log.Fatalln(err)
+    }
 
     coord := &Coordinates{
         Longitude: 53.343497,
@@ -187,7 +202,10 @@ func main() {
 
 ```Go
 func main() {
-    uv := NewUV()
+    uv, err := NewUV()
+    if err != nil {
+        log.Fatalln(err)
+    }
 
     coord := &Coordinates{
         Longitude: 54.995656,
@@ -207,7 +225,10 @@ func main() {
 
 ```Go
 func main() {
-    uv := NewUV()
+    uv, err := NewUV()
+    if err != nil {
+        log.Fatalln(err)
+    }
 
     if err := uv.Current(coords); err != nil {
         t.Error(err)
@@ -224,11 +245,14 @@ func main() {
 
 ```Go
 func main() {
-    pollution := NewPollution()
+    pollution, err := NewPollution()
+    if err != nil {
+        log.Fatalln(err)
+    }
 
-	params := &PollutionParameters{
-    	Location: Coordinates{
-        	Latitude:  0.0,
+    params := &PollutionParameters{
+        Location: Coordinates{
+            Latitude:  0.0,
             Longitude: 10.0,
         },
         Datetime: "current",

--- a/current.go
+++ b/current.go
@@ -17,7 +17,6 @@ package openweathermap
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 )
@@ -41,7 +40,7 @@ type CurrentWeatherData struct {
 	Unit    string
 	Lang    string
 	Key     string
-	Settings
+	*Settings
 }
 
 // NewCurrent returns a new CurrentWeatherData pointer with the supplied parameters
@@ -49,8 +48,9 @@ func NewCurrent(unit, lang string, options ...Option) (*CurrentWeatherData, erro
 	unitChoice := strings.ToUpper(unit)
 	langChoice := strings.ToUpper(lang)
 
-	c := &CurrentWeatherData{}
-	c.client = http.DefaultClient
+	c := &CurrentWeatherData{
+		Settings: NewSettings(),
+	}
 
 	if ValidDataUnit(unitChoice) {
 		c.Unit = DataUnits[unitChoice]

--- a/current.go
+++ b/current.go
@@ -78,10 +78,7 @@ func NewCurrent(unit, lang string, options ...Option) (*CurrentWeatherData, erro
 // CurrentByName will provide the current weather with the provided
 // location name.
 func (w *CurrentWeatherData) CurrentByName(location string) error {
-	var err error
-	var response *http.Response
-
-	response, err = w.client.Get(fmt.Sprintf(fmt.Sprintf(baseURL, "appid=%s&q=%s&units=%s&lang=%s"), w.Key, url.QueryEscape(location), w.Unit, w.Lang))
+	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(baseURL, "appid=%s&q=%s&units=%s&lang=%s"), w.Key, url.QueryEscape(location), w.Unit, w.Lang))
 	if err != nil {
 		return err
 	}

--- a/current.go
+++ b/current.go
@@ -41,18 +41,7 @@ type CurrentWeatherData struct {
 	Unit    string
 	Lang    string
 	Key     string
-	client  *http.Client
-}
-
-// Optional settings
-type Option func(w *CurrentWeatherData) error
-
-// Sets custom http client when creating a new CurrentWeatherData.
-func WithHttpClient(c *http.Client) Option {
-	return func(w *CurrentWeatherData) error {
-		w.client = c
-		return nil
-	}
+	Settings
 }
 
 // NewCurrent returns a new CurrentWeatherData pointer with the supplied parameters
@@ -78,7 +67,7 @@ func NewCurrent(unit, lang string, options ...Option) (*CurrentWeatherData, erro
 	c.Key = getKey()
 
 	for _, option := range options {
-		err := option(c)
+		err := option(c.Settings)
 		if err != nil {
 			return nil, err
 		}
@@ -145,7 +134,6 @@ func (w *CurrentWeatherData) CurrentByZip(zip int, countryCode string) error {
 		return err
 	}
 	defer response.Body.Close()
-
 	if err = json.NewDecoder(response.Body).Decode(&w); err != nil {
 		return err
 	}

--- a/current_test.go
+++ b/current_test.go
@@ -97,7 +97,7 @@ func TestNewCurrentWithInvalidHttpClient(t *testing.T) {
 		t.Logf("Received expected bad client error. message: %s", err.Error())
 	}
 	if c != nil {
-		t.Log("Expected nil, but got %v", c)
+		t.Errorf("Expected nil, but got %v", c)
 	}
 }
 

--- a/current_test.go
+++ b/current_test.go
@@ -16,10 +16,10 @@ package openweathermap
 
 import (
 	"log"
+	"net/http"
 	"os"
 	"reflect"
 	"testing"
-	"net/http"
 	"time"
 )
 
@@ -84,7 +84,7 @@ func TestNewCurrentWithCustomHttpClient(t *testing.T) {
 
 	expected := time.Duration(1) * time.Second
 	if c.client.Timeout != expected {
-		t.Errorf("Expect Duration %v, got %v", expected, c.client.Timeout)
+		t.Errorf("Expected Duration %v, but got %v", expected, c.client.Timeout)
 	}
 }
 

--- a/current_test.go
+++ b/current_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"net/http"
+	"time"
 )
 
 // currentWeather holds the query and response
@@ -62,6 +64,27 @@ func TestNewCurrent(t *testing.T) {
 		} else {
 			t.Errorf("unusable data unit - %s", d)
 		}
+	}
+}
+
+// TestNewCurrentWithCustomHttpClient will verify that a new instance of CurrentWeatherData
+// is created with custom http client
+func TestNewCurrentWithCustomHttpClient(t *testing.T) {
+
+	hc := http.DefaultClient
+	hc.Timeout = time.Duration(1) * time.Second
+	c, err := NewCurrent("c", "en", WithHttpClient(hc))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(c).String() != "*openweathermap.CurrentWeatherData" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := time.Duration(1) * time.Second
+	if c.client.Timeout != expected {
+		t.Errorf("Expect Duration %v, got %v", expected, c.client.Timeout)
 	}
 }
 

--- a/current_test.go
+++ b/current_test.go
@@ -88,6 +88,19 @@ func TestNewCurrentWithCustomHttpClient(t *testing.T) {
 	}
 }
 
+// TestNewCurrentWithInvalidHttpClient will verify that returns an error with
+// invalid http client
+func TestNewCurrentWithInvalidHttpClient(t *testing.T) {
+
+	c, err := NewCurrent("c", "en", WithHttpClient(nil))
+	if err != nil {
+		t.Logf("Received expected bad client error. message: %s", err.Error())
+	}
+	if c != nil {
+		t.Log("Expected nil, but got %v", c)
+	}
+}
+
 // TestCurrentByName will verify that current data can be retrieved for a give
 // location by name
 func TestCurrentByName(t *testing.T) {

--- a/forecast.go
+++ b/forecast.go
@@ -17,7 +17,6 @@ package openweathermap
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -72,7 +71,7 @@ type ForecastWeatherData struct {
 	Unit    string
 	Lang    string
 	Key     string
-	Settings
+	*Settings
 }
 
 // NewForecast returns a new HistoricalWeatherData pointer with
@@ -81,8 +80,9 @@ func NewForecast(unit, lang string, options ...Option) (*ForecastWeatherData, er
 	unitChoice := strings.ToUpper(unit)
 	langChoice := strings.ToUpper(lang)
 
-	f := &ForecastWeatherData{}
-	f.client = http.DefaultClient
+	f := &ForecastWeatherData{
+		Settings: NewSettings(),
+	}
 
 	if ValidDataUnit(unitChoice) {
 		f.Unit = DataUnits[unitChoice]

--- a/forecast.go
+++ b/forecast.go
@@ -110,10 +110,7 @@ func NewForecast(unit, lang string, options ...Option) (*ForecastWeatherData, er
 // DailyByName will provide a forecast for the location given for the
 // number of days given.
 func (f *ForecastWeatherData) DailyByName(location string, days int) error {
-	var err error
-	var response *http.Response
-
-	response, err = f.client.Get(fmt.Sprintf(forecastBase, f.Key, fmt.Sprintf("%s=%s", "q", url.QueryEscape(location)), f.Unit, f.Lang, days))
+	response, err := f.client.Get(fmt.Sprintf(forecastBase, f.Key, fmt.Sprintf("%s=%s", "q", url.QueryEscape(location)), f.Unit, f.Lang, days))
 	if err != nil {
 		return err
 	}

--- a/forecast.go
+++ b/forecast.go
@@ -72,15 +72,17 @@ type ForecastWeatherData struct {
 	Unit    string
 	Lang    string
 	Key     string
+	Settings
 }
 
 // NewForecast returns a new HistoricalWeatherData pointer with
 // the supplied arguments.
-func NewForecast(unit, lang string) (*ForecastWeatherData, error) {
+func NewForecast(unit, lang string, options ...Option) (*ForecastWeatherData, error) {
 	unitChoice := strings.ToUpper(unit)
 	langChoice := strings.ToUpper(lang)
 
 	f := &ForecastWeatherData{}
+	f.client = http.DefaultClient
 
 	if ValidDataUnit(unitChoice) {
 		f.Unit = DataUnits[unitChoice]
@@ -96,6 +98,12 @@ func NewForecast(unit, lang string) (*ForecastWeatherData, error) {
 
 	f.Key = getKey()
 
+	for _, option := range options {
+		err := option(f.Settings)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return f, nil
 }
 
@@ -105,7 +113,7 @@ func (f *ForecastWeatherData) DailyByName(location string, days int) error {
 	var err error
 	var response *http.Response
 
-	response, err = http.Get(fmt.Sprintf(forecastBase, f.Key, fmt.Sprintf("%s=%s","q", url.QueryEscape(location)), f.Unit, f.Lang, days))
+	response, err = f.client.Get(fmt.Sprintf(forecastBase, f.Key, fmt.Sprintf("%s=%s", "q", url.QueryEscape(location)), f.Unit, f.Lang, days))
 	if err != nil {
 		return err
 	}
@@ -121,7 +129,7 @@ func (f *ForecastWeatherData) DailyByName(location string, days int) error {
 // DailyByCoordinates will provide a forecast for the coordinates ID give
 // for the number of days given.
 func (f *ForecastWeatherData) DailyByCoordinates(location *Coordinates, days int) error {
-	response, err := http.Get(fmt.Sprintf(forecastBase, f.Key, fmt.Sprintf("lat=%f&lon=%f", location.Latitude, location.Longitude), f.Unit, f.Lang, days))
+	response, err := f.client.Get(fmt.Sprintf(forecastBase, f.Key, fmt.Sprintf("lat=%f&lon=%f", location.Latitude, location.Longitude), f.Unit, f.Lang, days))
 	if err != nil {
 		return err
 	}
@@ -137,7 +145,7 @@ func (f *ForecastWeatherData) DailyByCoordinates(location *Coordinates, days int
 // DailyByID will provide a forecast for the location ID give for the
 // number of days given.
 func (f *ForecastWeatherData) DailyByID(id, days int) error {
-	response, err := http.Get(fmt.Sprintf(forecastBase, f.Key, fmt.Sprintf("%s=%s","id", strconv.Itoa(id)), f.Unit, f.Lang, days))
+	response, err := f.client.Get(fmt.Sprintf(forecastBase, f.Key, fmt.Sprintf("%s=%s", "id", strconv.Itoa(id)), f.Unit, f.Lang, days))
 	if err != nil {
 		return err
 	}

--- a/forecast_test.go
+++ b/forecast_test.go
@@ -71,6 +71,19 @@ func TestNewForecastWithCustomHttpClient(t *testing.T) {
 	}
 }
 
+// TestNewForecastWithCustomHttpClient will verify that returns an error with
+// invalid http client
+func TestNewForecastWithInvalidHttpClient(t *testing.T) {
+
+	f, err := NewForecast("c", "en", WithHttpClient(nil))
+	if err != nil {
+		t.Logf("Received expected bad client error. message: %s", err.Error())
+	}
+	if f != nil {
+		t.Log("Expected nil, but got %v", f)
+	}
+}
+
 // TestDailyByName will verify that a daily forecast can be retrieved for
 // a given named location
 func TestDailyByName(t *testing.T) {

--- a/forecast_test.go
+++ b/forecast_test.go
@@ -80,7 +80,7 @@ func TestNewForecastWithInvalidHttpClient(t *testing.T) {
 		t.Logf("Received expected bad client error. message: %s", err.Error())
 	}
 	if f != nil {
-		t.Log("Expected nil, but got %v", f)
+		t.Errorf("Expected nil, but got %v", f)
 	}
 }
 

--- a/forecast_test.go
+++ b/forecast_test.go
@@ -15,8 +15,10 @@
 package openweathermap
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 var forecastRange = []int{3, 7, 10}
@@ -45,6 +47,27 @@ func TestNewForecast(t *testing.T) {
 	_, err := NewForecast("asdf", "en")
 	if err == nil {
 		t.Error("created instance when it shouldn't have")
+	}
+}
+
+// TestNewForecastWithCustomHttpClient will verify that a new instance of ForecastWeatherData
+// is created with custom http client
+func TestNewForecastWithCustomHttpClient(t *testing.T) {
+
+	hc := http.DefaultClient
+	hc.Timeout = time.Duration(1) * time.Second
+	f, err := NewForecast("c", "en", WithHttpClient(hc))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(f).String() != "*openweathermap.ForecastWeatherData" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := time.Duration(1) * time.Second
+	if f.client.Timeout != expected {
+		t.Errorf("Expected Duration %v, but got %v", expected, f.client.Timeout)
 	}
 }
 

--- a/history.go
+++ b/history.go
@@ -85,9 +85,7 @@ func NewHistorical(unit string, options ...Option) (*HistoricalWeatherData, erro
 
 // HistoryByName will return the history for the provided location
 func (h *HistoricalWeatherData) HistoryByName(location string) error {
-	var err error
-	var response *http.Response
-	response, err = h.client.Get(fmt.Sprintf(fmt.Sprintf(historyURL, "city?appid=%s&q=%s"), h.Key, url.QueryEscape(location)))
+	response, err := h.client.Get(fmt.Sprintf(fmt.Sprintf(historyURL, "city?appid=%s&q=%s"), h.Key, url.QueryEscape(location)))
 	if err != nil {
 		return err
 	}

--- a/history.go
+++ b/history.go
@@ -17,7 +17,6 @@ package openweathermap
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 )
@@ -57,14 +56,15 @@ type HistoricalWeatherData struct {
 	List     []WeatherHistory `json:"list"`
 	Unit     string
 	Key      string
-	Settings
+	*Settings
 }
 
 // NewHistorical returns a new HistoricalWeatherData pointer with
 //the supplied arguments.
 func NewHistorical(unit string, options ...Option) (*HistoricalWeatherData, error) {
-	h := &HistoricalWeatherData{}
-	h.client = http.DefaultClient
+	h := &HistoricalWeatherData{
+		Settings: NewSettings(),
+	}
 
 	unitChoice := strings.ToUpper(unit)
 	if !ValidDataUnit(unitChoice) {

--- a/history_test.go
+++ b/history_test.go
@@ -77,7 +77,7 @@ func TestNewHistoryWithInvalidHttpClient(t *testing.T) {
 		t.Logf("Received expected bad client error. message: %s", err.Error())
 	}
 	if h != nil {
-		t.Log("Expected nil, but got %v", h)
+		t.Errorf("Expected nil, but got %v", h)
 	}
 }
 

--- a/history_test.go
+++ b/history_test.go
@@ -15,8 +15,10 @@
 package openweathermap
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 // TestNewHistory verifies NewHistorical does as advertised
@@ -42,6 +44,27 @@ func TestNewHistory(t *testing.T) {
 	_, err := NewHistorical("asdf")
 	if err == nil {
 		t.Error("created instance when it shouldn't have")
+	}
+}
+
+// TestNewHistoryWithCustomHttpClient will verify that a new instance of HistoricalWeatherData
+// is created with custom http client
+func TestNewHistoryWithCustomHttpClient(t *testing.T) {
+
+	hc := http.DefaultClient
+	hc.Timeout = time.Duration(1) * time.Second
+	h, err := NewHistorical("c", WithHttpClient(hc))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(h).String() != "*openweathermap.HistoricalWeatherData" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := time.Duration(1) * time.Second
+	if h.client.Timeout != expected {
+		t.Errorf("Expected Duration %v, but got %v", expected, h.client.Timeout)
 	}
 }
 

--- a/history_test.go
+++ b/history_test.go
@@ -68,6 +68,19 @@ func TestNewHistoryWithCustomHttpClient(t *testing.T) {
 	}
 }
 
+// TestNewHistoryWithInvalidHttpClient will verify that returns an error with
+// invalid http client
+func TestNewHistoryWithInvalidHttpClient(t *testing.T) {
+
+	h, err := NewHistorical("c", WithHttpClient(nil))
+	if err != nil {
+		t.Logf("Received expected bad client error. message: %s", err.Error())
+	}
+	if h != nil {
+		t.Log("Expected nil, but got %v", h)
+	}
+}
+
 // TestHistoryByName
 func TestHistoryByName(t *testing.T) {
 	t.Parallel()

--- a/openweathermap.go
+++ b/openweathermap.go
@@ -16,6 +16,7 @@ package openweathermap
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -195,12 +196,22 @@ type Settings struct {
 	client *http.Client
 }
 
+// NewSettings returns a new Setting pointer with default http client.
+func NewSettings() *Settings {
+	return &Settings{
+		client: http.DefaultClient,
+	}
+}
+
 // Optional client settings
-type Option func(s Settings) error
+type Option func(s *Settings) error
 
 // WithHttpClient sets custom http client when creating a new Client.
 func WithHttpClient(c *http.Client) Option {
-	return func(s Settings) error {
+	return func(s *Settings) error {
+		if c == nil {
+			return fmt.Errorf("invalid http client.")
+		}
 		s.client = c
 		return nil
 	}

--- a/openweathermap.go
+++ b/openweathermap.go
@@ -17,6 +17,7 @@ package openweathermap
 import (
 	"errors"
 	"log"
+	"net/http"
 	"os"
 )
 
@@ -188,3 +189,19 @@ func ValidAPIKey(key string) bool {
 
 // CheckAPIKeyExists will see if an API key has been set.
 func (c *Config) CheckAPIKeyExists() bool { return len(c.APIKey) > 1 }
+
+// Settings holds the client settings
+type Settings struct {
+	client *http.Client
+}
+
+// Optional client settings
+type Option func(s Settings) error
+
+// WithHttpClient sets custom http client when creating a new Client.
+func WithHttpClient(c *http.Client) Option {
+	return func(s Settings) error {
+		s.client = c
+		return nil
+	}
+}

--- a/pollution.go
+++ b/pollution.go
@@ -3,7 +3,6 @@ package openweathermap
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 )
 
@@ -41,15 +40,15 @@ type Pollution struct {
 	Location Coordinates     `json:"location"`
 	Data     []PollutionData `json:"data"`
 	Key      string
-	Settings
+	*Settings
 }
 
 // NewPollution creates a new reference to Pollution
 func NewPollution(options ...Option) (*Pollution, error) {
 	p := &Pollution{
-		Key: getKey(),
+		Key:      getKey(),
+		Settings: NewSettings(),
 	}
-	p.client = http.DefaultClient
 
 	for _, option := range options {
 		err := option(p.Settings)

--- a/pollution.go
+++ b/pollution.go
@@ -41,13 +41,23 @@ type Pollution struct {
 	Location Coordinates     `json:"location"`
 	Data     []PollutionData `json:"data"`
 	Key      string
+	Settings
 }
 
 // NewPollution creates a new reference to Pollution
-func NewPollution() *Pollution {
-	return &Pollution{
+func NewPollution(options ...Option) (*Pollution, error) {
+	p := &Pollution{
 		Key: getKey(),
 	}
+	p.client = http.DefaultClient
+
+	for _, option := range options {
+		err := option(p.Settings)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return p, nil
 }
 
 // PollutionByParams gets the pollution data based on the given parameters
@@ -58,7 +68,7 @@ func (p *Pollution) PollutionByParams(params *PollutionParameters) error {
 		strconv.FormatFloat(params.Location.Longitude, 'f', -1, 64),
 		params.Datetime,
 		p.Key)
-	response, err := http.Get(url)
+	response, err := p.client.Get(url)
 	if err != nil {
 		return err
 	}

--- a/pollution_test.go
+++ b/pollution_test.go
@@ -40,6 +40,19 @@ func TestNewPollutionWithCustomHttpClient(t *testing.T) {
 	}
 }
 
+// TestNewPollutionWithInvalidHttpClient will verify that returns an error with
+// invalid http client
+func TestNewPollutionWithInvalidHttpClient(t *testing.T) {
+
+	p, err := NewPollution(WithHttpClient(nil))
+	if err != nil {
+		t.Logf("Received expected bad client error. message: %s", err.Error())
+	}
+	if p != nil {
+		t.Log("Expected nil, but got %v", p)
+	}
+}
+
 func TestValidAlias(t *testing.T) {
 	t.Parallel()
 	testAliases := []string{"now", "then", "current"}

--- a/pollution_test.go
+++ b/pollution_test.go
@@ -1,8 +1,44 @@
 package openweathermap
 
 import (
+	"net/http"
+	"reflect"
 	"testing"
+	"time"
 )
+
+// TestNewPollution
+func TestNewPollution(t *testing.T) {
+
+	p, err := NewPollution()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(p).String() != "*openweathermap.Pollution" {
+		t.Error("incorrect data type returned")
+	}
+}
+
+// TestNewPollution with custom http client
+func TestNewPollutionWithCustomHttpClient(t *testing.T) {
+
+	hc := http.DefaultClient
+	hc.Timeout = time.Duration(1) * time.Second
+	p, err := NewPollution(WithHttpClient(hc))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(p).String() != "*openweathermap.Pollution" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := time.Duration(1) * time.Second
+	if p.client.Timeout != expected {
+		t.Errorf("Expected Duration %v, but got %v", expected, p.client.Timeout)
+	}
+}
 
 func TestValidAlias(t *testing.T) {
 	t.Parallel()
@@ -17,7 +53,10 @@ func TestValidAlias(t *testing.T) {
 // TestPollutionByParams tests the call to the pollution API
 func TestPollutionByParams(t *testing.T) {
 	t.Parallel()
-	p := NewPollution()
+	p, err := NewPollution()
+	if err != nil {
+		t.Error(err)
+	}
 	params := &PollutionParameters{
 		Location: Coordinates{
 			Latitude:  0.0,

--- a/pollution_test.go
+++ b/pollution_test.go
@@ -49,7 +49,7 @@ func TestNewPollutionWithInvalidHttpClient(t *testing.T) {
 		t.Logf("Received expected bad client error. message: %s", err.Error())
 	}
 	if p != nil {
-		t.Log("Expected nil, but got %v", p)
+		t.Errorf("Expected nil, but got %v", p)
 	}
 }
 

--- a/uv.go
+++ b/uv.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"time"
 )
 
@@ -27,15 +26,15 @@ type UV struct {
 	DT    int64   `json:"dt,omitempty"`
 	Value float64 `json:"value,omitempty"`
 	Key   string
-	Settings
+	*Settings
 }
 
 // NewUV creates a new reference to UV
 func NewUV(options ...Option) (*UV, error) {
 	u := &UV{
-		Key: getKey(),
+		Key:      getKey(),
+		Settings: NewSettings(),
 	}
-	u.client = http.DefaultClient
 
 	for _, option := range options {
 		err := option(u.Settings)

--- a/uv.go
+++ b/uv.go
@@ -26,16 +26,29 @@ type UV struct {
 	} `json:"data,omitempty"`*/
 	DT    int64   `json:"dt,omitempty"`
 	Value float64 `json:"value,omitempty"`
+	Key   string
+	Settings
 }
 
 // NewUV creates a new reference to UV
-func NewUV() *UV {
-	return &UV{}
+func NewUV(options ...Option) (*UV, error) {
+	u := &UV{
+		Key: getKey(),
+	}
+	u.client = http.DefaultClient
+
+	for _, option := range options {
+		err := option(u.Settings)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return u, nil
 }
 
 // Current gets the current UV data for the given coordinates
 func (u *UV) Current(coord *Coordinates) error {
-	response, err := http.Get(fmt.Sprintf("%scurrent?lat=%f&lon=%f&appid=%s", uvURL, coord.Latitude, coord.Longitude, getKey()))
+	response, err := u.client.Get(fmt.Sprintf("%scurrent?lat=%f&lon=%f&appid=%s", uvURL, coord.Latitude, coord.Longitude, u.Key))
 	if err != nil {
 		return err
 	}
@@ -50,7 +63,7 @@ func (u *UV) Current(coord *Coordinates) error {
 
 // Historical gets the historical UV data for the coordinates and times
 func (u *UV) Historical(coord *Coordinates, start, end time.Time) error {
-	response, err := http.Get(fmt.Sprintf("%slist?lat=%f&lon=%f&from=%d&to=%d&appid=%s", uvURL, coord.Latitude, coord.Longitude, start, end, getKey()))
+	response, err := u.client.Get(fmt.Sprintf("%slist?lat=%f&lon=%f&from=%d&to=%d&appid=%s", uvURL, coord.Latitude, coord.Longitude, start, end, u.Key))
 	if err != nil {
 		return err
 	}

--- a/uv_test.go
+++ b/uv_test.go
@@ -45,6 +45,19 @@ func TestNewUVWithCustomHttpClient(t *testing.T) {
 	}
 }
 
+// TestNewUVWithInvalidHttpClient will verify that returns an error with
+// invalid http client
+func TestNewUVWithInvalidHttpClient(t *testing.T) {
+
+	uv, err := NewUV(WithHttpClient(nil))
+	if err != nil {
+		t.Logf("Received expected bad client error. message: %s", err.Error())
+	}
+	if uv != nil {
+		t.Log("Expected nil, but got %v", uv)
+	}
+}
+
 // TestCurrentUV
 func TestCurrentUV(t *testing.T) {
 	t.Parallel()

--- a/uv_test.go
+++ b/uv_test.go
@@ -54,7 +54,7 @@ func TestNewUVWithInvalidHttpClient(t *testing.T) {
 		t.Logf("Received expected bad client error. message: %s", err.Error())
 	}
 	if uv != nil {
-		t.Log("Expected nil, but got %v", uv)
+		t.Errorf("Expected nil, but got %v", uv)
 	}
 }
 

--- a/uv_test.go
+++ b/uv_test.go
@@ -1,8 +1,10 @@
 package openweathermap
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
+	"time"
 )
 
 var coords = &Coordinates{
@@ -10,11 +12,47 @@ var coords = &Coordinates{
 	Latitude:  -6.288379,
 }
 
+// TestNewUV
+func TestNewUV(t *testing.T) {
+
+	uv, err := NewUV()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(uv).String() != "*openweathermap.UV" {
+		t.Error("incorrect data type returned")
+	}
+}
+
+// TestNewUV with custom http client
+func TestNewUVWithCustomHttpClient(t *testing.T) {
+
+	hc := http.DefaultClient
+	hc.Timeout = time.Duration(1) * time.Second
+	uv, err := NewUV(WithHttpClient(hc))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(uv).String() != "*openweathermap.UV" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := time.Duration(1) * time.Second
+	if uv.client.Timeout != expected {
+		t.Errorf("Expected Duration %v, but got %v", expected, uv.client.Timeout)
+	}
+}
+
 // TestCurrentUV
 func TestCurrentUV(t *testing.T) {
 	t.Parallel()
 
-	uv := NewUV()
+	uv, err := NewUV()
+	if err != nil {
+		t.Error(err)
+	}
 
 	if err := uv.Current(coords); err != nil {
 		t.Error(err)
@@ -46,13 +84,16 @@ func TestHistoricalUV(t *testing.T) {
 func TestUVInformation(t *testing.T) {
 	t.Parallel()
 
-	uv := NewUV()
+	uv, err := NewUV()
+	if err != nil {
+		t.Error(err)
+	}
 
 	if err := uv.Current(coords); err != nil {
 		t.Error(err)
 	}
 
-	_, err := uv.UVInformation()
+	_, err = uv.UVInformation()
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Added a feature to configure http client.

I want to use this awesome library for my apps on Google App Engine Go (GAE/GO),
but it requires to use it’s own http.Client implementation to create outbound request from GAE/GO.

https://cloud.google.com/appengine/docs/go/outbound-requests

So I’ve added this new feature to overcome this issue.

### Concept
* Don’t make any changes to existing API’s as possible

### Changes
Add an interface to configure custom http client on below.

* NewCurrent
* NewForecast
* NewHistorical
* NewPollution
* NewUV

### Usages
```
func main() {
    client := &http.Client{}
    w, err := owm.NewCurrent("F", "EN", owm.WithHttpClient(client))
    if err != nil {
        log.Fatalln(err)
    }
}
```

### Changes in the existing API
I had to change the current api on below. it returns `error` if something went wrong in the function.

* NewPollution
* NewUV