### PR TITLE
Removed use of environment variable 'OWM_API_KEY'

### DIFF
--- a/current.go
+++ b/current.go
@@ -44,7 +44,7 @@ type CurrentWeatherData struct {
 }
 
 // NewCurrent returns a new CurrentWeatherData pointer with the supplied parameters
-func NewCurrent(unit, lang string, options ...Option) (*CurrentWeatherData, error) {
+func NewCurrent(unit, lang, key string, options ...Option) (*CurrentWeatherData, error) {
 	unitChoice := strings.ToUpper(unit)
 	langChoice := strings.ToUpper(lang)
 
@@ -64,7 +64,7 @@ func NewCurrent(unit, lang string, options ...Option) (*CurrentWeatherData, erro
 		return nil, errLangUnavailable
 	}
 
-	c.Key = getKey()
+	c.Key = setKey(key)
 
 	if err := setOptions(c.Settings, options); err != nil {
 		return nil, err

--- a/forecast.go
+++ b/forecast.go
@@ -76,7 +76,7 @@ type ForecastWeatherData struct {
 
 // NewForecast returns a new HistoricalWeatherData pointer with
 // the supplied arguments.
-func NewForecast(unit, lang string, options ...Option) (*ForecastWeatherData, error) {
+func NewForecast(unit, lang, key string, options ...Option) (*ForecastWeatherData, error) {
 	unitChoice := strings.ToUpper(unit)
 	langChoice := strings.ToUpper(lang)
 
@@ -96,7 +96,7 @@ func NewForecast(unit, lang string, options ...Option) (*ForecastWeatherData, er
 		return nil, errLangUnavailable
 	}
 
-	f.Key = getKey()
+	f.Key = setKey(key)
 
 	if err := setOptions(f.Settings, options); err != nil {
 		return nil, err

--- a/history.go
+++ b/history.go
@@ -61,7 +61,7 @@ type HistoricalWeatherData struct {
 
 // NewHistorical returns a new HistoricalWeatherData pointer with
 //the supplied arguments.
-func NewHistorical(unit string, options ...Option) (*HistoricalWeatherData, error) {
+func NewHistorical(unit, key string, options ...Option) (*HistoricalWeatherData, error) {
 	h := &HistoricalWeatherData{
 		Settings: NewSettings(),
 	}
@@ -72,7 +72,7 @@ func NewHistorical(unit string, options ...Option) (*HistoricalWeatherData, erro
 	}
 	h.Unit = DataUnits[unitChoice]
 
-	h.Key = getKey()
+	h.Key = setKey(key)
 
 	if err := setOptions(h.Settings, options); err != nil {
 		return nil, err

--- a/openweathermap.go
+++ b/openweathermap.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"log"
 	"net/http"
-	"os"
 )
 
 var errUnitUnavailable = errors.New("unit unavailable")
@@ -134,13 +133,19 @@ type Clouds struct {
 	All int `json:"all"`
 }
 
-func getKey() string {
-	key := os.Getenv("OWM_API_KEY")
+// func getKey() string {
+// 	key := os.Getenv("OWM_API_KEY")
 
+// 	if !ValidAPIKey(key) {
+// 		log.Fatalln(errInvalidKey)
+// 	}
+
+// 	return key
+// }
+func setKey(key string) string {
 	if !ValidAPIKey(key) {
 		log.Fatalln(errInvalidKey)
 	}
-
 	return key
 }
 

--- a/pollution.go
+++ b/pollution.go
@@ -44,9 +44,9 @@ type Pollution struct {
 }
 
 // NewPollution creates a new reference to Pollution
-func NewPollution(options ...Option) (*Pollution, error) {
+func NewPollution(key string, options ...Option) (*Pollution, error) {
 	p := &Pollution{
-		Key:      getKey(),
+		Key:      setKey(key),
 		Settings: NewSettings(),
 	}
 

--- a/uv.go
+++ b/uv.go
@@ -30,9 +30,9 @@ type UV struct {
 }
 
 // NewUV creates a new reference to UV
-func NewUV(options ...Option) (*UV, error) {
+func NewUV(key string, options ...Option) (*UV, error) {
 	u := &UV{
-		Key:      getKey(),
+		Key:      setKey(key),
 		Settings: NewSettings(),
 	}
 


### PR DESCRIPTION
We shouldn't depend on users declaring environment variables.