### PR TITLE
fix unmarshaling of forecast data

### DIFF
--- a/forecast.go
+++ b/forecast.go
@@ -63,8 +63,8 @@ type ForecastWeatherList struct {
 
 // ForecastWeatherData will hold returned data from queries
 type ForecastWeatherData struct {
-	COD     string                `json:"cod"`
-	Message float64               `json:"message"`
+	COD     int                   `json:"cod"`
+	Message string                `json:"message"`
 	City    City                  `json:"city"`
 	Cnt     int                   `json:"cnt"`
 	List    []ForecastWeatherList `json:"list"`

--- a/forecast_test.go
+++ b/forecast_test.go
@@ -121,7 +121,10 @@ func TestDailyByName(t *testing.T) {
 	}
 
 	for _, d := range forecastRange {
-		f.DailyByName("Dubai", d)
+		err = f.DailyByName("Dubai", d)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 }
 
@@ -136,12 +139,15 @@ func TestDailyByCoordinates(t *testing.T) {
 	}
 
 	for _, d := range forecastRange {
-		f.DailyByCoordinates(
+		err = f.DailyByCoordinates(
 			&Coordinates{
 				Longitude: -112.07,
 				Latitude:  33.45,
 			}, d,
 		)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 }
 
@@ -156,6 +162,9 @@ func TestDailyByID(t *testing.T) {
 	}
 
 	for _, d := range forecastRange {
-		f.DailyByID(524901, d)
+		err = f.DailyByID(524901, d)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 }


### PR DESCRIPTION
Forecast data failed to be parsed upon download because of wrong data types in structs. Checks for this error are also included in tests now.