### PR TITLE
Instead of failing or panicking, skip tests

### DIFF
--- a/current_test.go
+++ b/current_test.go
@@ -41,6 +41,10 @@ func TestValidLanguageCode(t *testing.T) {
 
 // TestNewCurrent will verify that a new instance of CurrentWeatherData is created
 func TestNewCurrent(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 
 	for d := range DataUnits {
@@ -66,18 +70,22 @@ func TestNewCurrent(t *testing.T) {
 	}
 }
 
-// TestNewCurrentWithCustomHttpClient will verify that a new instance of CurrentWeatherData
-// is created with custom http client
+// TestNewCurrentWithCustomHttpClient will verify that a new instance of
+// CurrentWeatherData is created with custom http client
 func TestNewCurrentWithCustomHttpClient(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	hc := http.DefaultClient
 	hc.Timeout = time.Duration(1) * time.Second
-	c, err := NewCurrent("c", "en", os.Getenv("OWM_API_KEY"), WithHttpClient(hc))
+	c, err := NewCurrent("c", "en", os.Getenv("OWM_API_KEY"),
+		WithHttpClient(hc))
 	if err != nil {
 		t.Error(err)
 	}
 
-	if reflect.TypeOf(c).String() != "*openweathermap.CurrentWeatherData" {
+	if reflect.TypeOf(c) != reflect.TypeOf(&CurrentWeatherData{}) {
 		t.Error("incorrect data type returned")
 	}
 
@@ -90,6 +98,9 @@ func TestNewCurrentWithCustomHttpClient(t *testing.T) {
 // TestNewCurrentWithInvalidOptions will verify that returns an error with
 // invalid option
 func TestNewCurrentWithInvalidOptions(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	optionsPattern := [][]Option{
 		{nil},
@@ -114,6 +125,9 @@ func TestNewCurrentWithInvalidOptions(t *testing.T) {
 // TestNewCurrentWithInvalidHttpClient will verify that returns an error with
 // invalid http client
 func TestNewCurrentWithInvalidHttpClient(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	c, err := NewCurrent("c", "en", os.Getenv("OWM_API_KEY"), WithHttpClient(nil))
 	if err == errInvalidHttpClient {
@@ -129,6 +143,10 @@ func TestNewCurrentWithInvalidHttpClient(t *testing.T) {
 // TestCurrentByName will verify that current data can be retrieved for a give
 // location by name
 func TestCurrentByName(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 
 	testCities := []currentWeather{
@@ -207,6 +225,10 @@ func TestCurrentByName(t *testing.T) {
 // TestCurrentByCoordinates will verify that current data can be retrieved for a
 // given set of coordinates
 func TestCurrentByCoordinates(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 	c, err := NewCurrent("f", "DE", os.Getenv("OWM_API_KEY"))
 	if err != nil {
@@ -223,6 +245,10 @@ func TestCurrentByCoordinates(t *testing.T) {
 // TestCurrentByID will verify that current data can be retrieved for a given
 // location id
 func TestCurrentByID(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 	c, err := NewCurrent("c", "ZH", os.Getenv("OWM_API_KEY"))
 	if err != nil {
@@ -232,6 +258,10 @@ func TestCurrentByID(t *testing.T) {
 }
 
 func TestCurrentByZip(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	w, err := NewCurrent("F", "EN", os.Getenv("OWM_API_KEY"))
 	if err != nil {
 		t.Error(err)

--- a/forecast_test.go
+++ b/forecast_test.go
@@ -26,6 +26,10 @@ var forecastRange = []int{3, 7, 10}
 
 // TestNewForecast will make sure the a new instance of Forecast is returned
 func TestNewForecast(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 
 	for d := range DataUnits {
@@ -63,6 +67,9 @@ func TestNewForecast(t *testing.T) {
 // TestNewForecastWithCustomHttpClient will verify that a new instance of ForecastWeatherData
 // is created with custom http client
 func TestNewForecastWithCustomHttpClient(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	hc := http.DefaultClient
 	hc.Timeout = time.Duration(1) * time.Second
@@ -108,6 +115,9 @@ func TestNewForecastWithInvalidOptions(t *testing.T) {
 // TestNewForecastWithCustomHttpClient will verify that returns an error with
 // invalid http client
 func TestNewForecastWithInvalidHttpClient(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	f, err := NewForecast("5", "c", "en", os.Getenv("OWM_API_KEY"), WithHttpClient(nil))
 	if err == errInvalidHttpClient {
@@ -123,6 +133,10 @@ func TestNewForecastWithInvalidHttpClient(t *testing.T) {
 // TestDailyByName will verify that a daily forecast can be retrieved for
 // a given named location
 func TestDailyByName(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 
 	f, err := NewForecast("5", "f", "fi", os.Getenv("OWM_API_KEY"))
@@ -138,9 +152,13 @@ func TestDailyByName(t *testing.T) {
 	}
 }
 
-// TestDailyByCooridinates will verify that a daily forecast can be retrieved
+// TestDailyByCoordinates will verify that a daily forecast can be retrieved
 // for a given set of coordinates
 func TestDailyByCoordinates(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 
 	f, err := NewForecast("5", "f", "PL", os.Getenv("OWM_API_KEY"))
@@ -164,6 +182,10 @@ func TestDailyByCoordinates(t *testing.T) {
 // TestDailyByID will verify that a daily forecast can be retrieved for a
 // given location ID
 func TestDailyByID(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 
 	f, err := NewForecast("5", "c", "fr", os.Getenv("OWM_API_KEY"))

--- a/history_test.go
+++ b/history_test.go
@@ -24,6 +24,10 @@ import (
 
 // TestNewHistory verifies NewHistorical does as advertised
 func TestNewHistory(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 
 	for d := range DataUnits {
@@ -51,6 +55,9 @@ func TestNewHistory(t *testing.T) {
 // TestNewHistoryWithCustomHttpClient will verify that a new instance of HistoricalWeatherData
 // is created with custom http client
 func TestNewHistoryWithCustomHttpClient(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	hc := http.DefaultClient
 	hc.Timeout = time.Duration(1) * time.Second
@@ -72,6 +79,9 @@ func TestNewHistoryWithCustomHttpClient(t *testing.T) {
 // TestNewHistoryWithInvalidOptions will verify that returns an error with
 // invalid option
 func TestNewHistoryWithInvalidOptions(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	optionsPattern := [][]Option{
 		{nil},
@@ -96,6 +106,9 @@ func TestNewHistoryWithInvalidOptions(t *testing.T) {
 // TestNewHistoryWithInvalidHttpClient will verify that returns an error with
 // invalid http client
 func TestNewHistoryWithInvalidHttpClient(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	h, err := NewHistorical("c", os.Getenv("OWM_API_KEY"), WithHttpClient(nil))
 	if err == errInvalidHttpClient {
@@ -110,6 +123,10 @@ func TestNewHistoryWithInvalidHttpClient(t *testing.T) {
 
 // TestHistoryByName
 func TestHistoryByName(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 	h, err := NewHistorical("F", os.Getenv("OWM_API_KEY"))
 	if err != nil {
@@ -122,6 +139,10 @@ func TestHistoryByName(t *testing.T) {
 
 // TestHistoryByID
 func TestHistoryByID(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 	h, err := NewHistorical("F", os.Getenv("OWM_API_KEY"))
 	if err != nil {
@@ -139,6 +160,10 @@ func TestHistoryByID(t *testing.T) {
 
 // TestHistoryByCoord
 func TestHistoryByCoord(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 	h, err := NewHistorical("F", os.Getenv("OWM_API_KEY"))
 	if err != nil {

--- a/pollution_test.go
+++ b/pollution_test.go
@@ -10,6 +10,9 @@ import (
 
 // TestNewPollution
 func TestNewPollution(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	p, err := NewPollution(os.Getenv("OWM_API_KEY"))
 	if err != nil {
@@ -22,7 +25,10 @@ func TestNewPollution(t *testing.T) {
 }
 
 // TestNewPollution with custom http client
-func TestNewPollutionWithCustomHttpClient(t *testing.T) {
+func WithCustomHttpClient(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	hc := http.DefaultClient
 	hc.Timeout = time.Duration(1) * time.Second
@@ -44,6 +50,9 @@ func TestNewPollutionWithCustomHttpClient(t *testing.T) {
 // TestNewPollutionWithInvalidOptions will verify that returns an error with
 // invalid option
 func TestNewPollutionWithInvalidOptions(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	optionsPattern := [][]Option{
 		{nil},
@@ -68,6 +77,9 @@ func TestNewPollutionWithInvalidOptions(t *testing.T) {
 // TestNewPollutionWithInvalidHttpClient will verify that returns an error with
 // invalid http client
 func TestNewPollutionWithInvalidHttpClient(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	p, err := NewPollution(os.Getenv("OWM_API_KEY"), WithHttpClient(nil))
 	if err == errInvalidHttpClient {
@@ -92,6 +104,10 @@ func TestValidAlias(t *testing.T) {
 
 // TestPollutionByParams tests the call to the pollution API
 func TestPollutionByParams(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 	p, err := NewPollution(os.Getenv("OWM_API_KEY"))
 	if err != nil {

--- a/uv_test.go
+++ b/uv_test.go
@@ -15,6 +15,9 @@ var coords = &Coordinates{
 
 // TestNewUV
 func TestNewUV(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	uv, err := NewUV(os.Getenv("OWM_API_KEY"))
 	if err != nil {
@@ -28,6 +31,9 @@ func TestNewUV(t *testing.T) {
 
 // TestNewUV with custom http client
 func TestNewUVWithCustomHttpClient(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	hc := http.DefaultClient
 	hc.Timeout = time.Duration(1) * time.Second
@@ -49,6 +55,9 @@ func TestNewUVWithCustomHttpClient(t *testing.T) {
 // TestNewUVWithInvalidOptions will verify that returns an error with
 // invalid option
 func TestNewUVWithInvalidOptions(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	optionsPattern := [][]Option{
 		{nil},
@@ -73,6 +82,9 @@ func TestNewUVWithInvalidOptions(t *testing.T) {
 // TestNewUVWithInvalidHttpClient will verify that returns an error with
 // invalid http client
 func TestNewUVWithInvalidHttpClient(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
 
 	uv, err := NewUV(os.Getenv("OWM_API_KEY"), WithHttpClient(nil))
 	if err == errInvalidHttpClient {
@@ -87,6 +99,10 @@ func TestNewUVWithInvalidHttpClient(t *testing.T) {
 
 // TestCurrentUV
 func TestCurrentUV(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 
 	uv, err := NewUV(os.Getenv("OWM_API_KEY"))
@@ -122,6 +138,10 @@ func TestHistoricalUV(t *testing.T) {
 }
 
 func TestUVInformation(t *testing.T) {
+	if os.Getenv("OWM_API_KEY") == "" {
+		t.Skip("OWM_API_KEY environment variable not set, skipping test")
+	}
+
 	t.Parallel()
 
 	uv, err := NewUV(os.Getenv("OWM_API_KEY"))


### PR DESCRIPTION
Based on the fact that an API key is required, automated tests done via TravisCI and such fail without it, and in some instances lead to a panic and recovery. Instead, perhaps this is a better alternative to tests that just cannot possibly pass. Skipping may not be a lot better than a failure, but at least as many as possible runnable tests actually run.