### PR TITLE
Add API url option

### DIFF
--- a/current.go
+++ b/current.go
@@ -79,7 +79,7 @@ func NewCurrent(unit, lang, key string, options ...Option) (*CurrentWeatherData,
 // CurrentByName will provide the current weather with the provided
 // location name.
 func (w *CurrentWeatherData) CurrentByName(location string) error {
-	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(baseURL, "appid=%s&q=%s&units=%s&lang=%s"), w.Key, url.QueryEscape(location), w.Unit, w.Lang))
+	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(w.baseURL, "appid=%s&q=%s&units=%s&lang=%s"), w.Key, url.QueryEscape(location), w.Unit, w.Lang))
 	if err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (w *CurrentWeatherData) CurrentByName(location string) error {
 // CurrentByCoordinates will provide the current weather with the
 // provided location coordinates.
 func (w *CurrentWeatherData) CurrentByCoordinates(location *Coordinates) error {
-	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(baseURL, "appid=%s&lat=%f&lon=%f&units=%s&lang=%s"), w.Key, location.Latitude, location.Longitude, w.Unit, w.Lang))
+	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(w.baseURL, "appid=%s&lat=%f&lon=%f&units=%s&lang=%s"), w.Key, location.Latitude, location.Longitude, w.Unit, w.Lang))
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (w *CurrentWeatherData) CurrentByCoordinates(location *Coordinates) error {
 // CurrentByID will provide the current weather with the
 // provided location ID.
 func (w *CurrentWeatherData) CurrentByID(id int) error {
-	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(baseURL, "appid=%s&id=%d&units=%s&lang=%s"), w.Key, id, w.Unit, w.Lang))
+	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(w.baseURL, "appid=%s&id=%d&units=%s&lang=%s"), w.Key, id, w.Unit, w.Lang))
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (w *CurrentWeatherData) CurrentByID(id int) error {
 // CurrentByZip will provide the current weather for the
 // provided zip code.
 func (w *CurrentWeatherData) CurrentByZip(zip int, countryCode string) error {
-	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(baseURL, "appid=%s&zip=%d,%s&units=%s&lang=%s"), w.Key, zip, countryCode, w.Unit, w.Lang))
+	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(w.baseURL, "appid=%s&zip=%d,%s&units=%s&lang=%s"), w.Key, zip, countryCode, w.Unit, w.Lang))
 	if err != nil {
 		return err
 	}

--- a/current_test.go
+++ b/current_test.go
@@ -123,6 +123,39 @@ func TestNewCurrentWithInvalidHttpClient(t *testing.T) {
 	}
 }
 
+// TestNewCurrentWithApiURL  will verify that a new instance of CurrentWeatherData
+// is created with custom API url
+func TestNewCurrentWithApiURL(t *testing.T) {
+	c, err := NewCurrent("c", "en", os.Getenv("OWM_API_KEY"), WithApiURL("https://ru.openweathermap.org/"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(c).String() != "*openweathermap.CurrentWeatherData" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := "https://ru.openweathermap.org/data/2.5/weather?%s"
+	got := c.baseURL
+	if got != expected {
+		t.Errorf("Expected baseURL %v, but got %v", expected, got)
+	}
+}
+
+// TestNewCurrentWithInvalidApiURL  will verify that returns an error with
+// invalid API url
+func TestNewCurrentWithInvalidApiURL(t *testing.T) {
+	c, err := NewCurrent("c", "en", os.Getenv("OWM_API_KEY"), WithApiURL("somestring"))
+	if err == errInvalidApiURL {
+		t.Logf("Received expected invalid url error. message: %s", err.Error())
+	} else if err != nil {
+		t.Errorf("Expected %v, but got %v", errInvalidApiURL, err)
+	}
+	if c != nil {
+		t.Errorf("Expected nil, but got %v", c)
+	}
+}
+
 // TestCurrentByName will verify that current data can be retrieved for a give
 // location by name
 func TestCurrentByName(t *testing.T) {

--- a/forecast.go
+++ b/forecast.go
@@ -104,10 +104,10 @@ func NewForecast(forecastType, unit, lang, key string, options ...Option) (*Fore
 	}
 
 	if forecastType == "16" {
-		forecastData.baseURL = forecast16Base
+		forecastData.baseURL = settings.forecast16Base
 		forecastData.ForecastWeatherJson = &Forecast16WeatherData{}
 	} else {
-		forecastData.baseURL = forecast5Base
+		forecastData.baseURL = settings.forecast5Base
 		forecastData.ForecastWeatherJson = &Forecast5WeatherData{}
 	}
 

--- a/forecast_test.go
+++ b/forecast_test.go
@@ -120,6 +120,58 @@ func TestNewForecastWithInvalidHttpClient(t *testing.T) {
 	}
 }
 
+// TestNewForecast5WithApiURL  will verify that a new instance of ForecastWeatherData
+// is created with custom API url
+func TestNewForecast5WithApiURL(t *testing.T) {
+	c, err := NewForecast("5", "c", "en", os.Getenv("OWM_API_KEY"), WithApiURL("https://ru.openweathermap.org/"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(c).String() != "*openweathermap.ForecastWeatherData" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := "https://ru.openweathermap.org/data/2.5/forecast?appid=%s&%s&mode=json&units=%s&lang=%s&cnt=%d"
+	got := c.baseURL
+	if got != expected {
+		t.Errorf("Expected baseURL %v, but got %v", expected, got)
+	}
+}
+
+// TestNewForecast16WithApiURL  will verify that a new instance of ForecastWeatherData
+// is created with custom API url
+func TestNewForecast16WithApiURL(t *testing.T) {
+	c, err := NewForecast("16", "c", "en", os.Getenv("OWM_API_KEY"), WithApiURL("https://ru.openweathermap.org/"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(c).String() != "*openweathermap.ForecastWeatherData" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := "https://ru.openweathermap.org/data/2.5/forecast/daily?appid=%s&%s&mode=json&units=%s&lang=%s&cnt=%d"
+	got := c.baseURL
+	if got != expected {
+		t.Errorf("Expected baseURL %v, but got %v", expected, got)
+	}
+}
+
+// TestNewForecastWithInvalidApiURL  will verify that returns an error with
+// invalid API url
+func TestNewForecastWithInvalidApiURL(t *testing.T) {
+	c, err := NewForecast("5", "c", "en", os.Getenv("OWM_API_KEY"), WithApiURL("somestring"))
+	if err == errInvalidApiURL {
+		t.Logf("Received expected invalid url error. message: %s", err.Error())
+	} else if err != nil {
+		t.Errorf("Expected %v, but got %v", errInvalidApiURL, err)
+	}
+	if c != nil {
+		t.Errorf("Expected nil, but got %v", c)
+	}
+}
+
 // TestDailyByName will verify that a daily forecast can be retrieved for
 // a given named location
 func TestDailyByName(t *testing.T) {

--- a/history.go
+++ b/history.go
@@ -93,7 +93,7 @@ func NewHistorical(unit, key string, options ...Option) (*HistoricalWeatherData,
 
 // HistoryByName will return the history for the provided location
 func (h *HistoricalWeatherData) HistoryByName(location string) error {
-	response, err := h.client.Get(fmt.Sprintf(fmt.Sprintf(historyURL, "city?appid=%s&q=%s"), h.Key, url.QueryEscape(location)))
+	response, err := h.client.Get(fmt.Sprintf(fmt.Sprintf(h.historyURL, "city?appid=%s&q=%s"), h.Key, url.QueryEscape(location)))
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func (h *HistoricalWeatherData) HistoryByName(location string) error {
 // HistoryByID will return the history for the provided location ID
 func (h *HistoricalWeatherData) HistoryByID(id int, hp ...*HistoricalParameters) error {
 	if len(hp) > 0 {
-		response, err := h.client.Get(fmt.Sprintf(fmt.Sprintf(historyURL, "city?appid=%s&id=%d&type=hour&start%d&end=%d&cnt=%d"), h.Key, id, hp[0].Start, hp[0].End, hp[0].Cnt))
+		response, err := h.client.Get(fmt.Sprintf(fmt.Sprintf(h.historyURL, "city?appid=%s&id=%d&type=hour&start%d&end=%d&cnt=%d"), h.Key, id, hp[0].Start, hp[0].End, hp[0].Cnt))
 		if err != nil {
 			return err
 		}
@@ -120,7 +120,7 @@ func (h *HistoricalWeatherData) HistoryByID(id int, hp ...*HistoricalParameters)
 		}
 	}
 
-	response, err := h.client.Get(fmt.Sprintf(fmt.Sprintf(historyURL, "city?appid=%s&id=%d"), h.Key, id))
+	response, err := h.client.Get(fmt.Sprintf(fmt.Sprintf(h.historyURL, "city?appid=%s&id=%d"), h.Key, id))
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func (h *HistoricalWeatherData) HistoryByID(id int, hp ...*HistoricalParameters)
 
 // HistoryByCoord will return the history for the provided coordinates
 func (h *HistoricalWeatherData) HistoryByCoord(location *Coordinates, hp *HistoricalParameters) error {
-	response, err := h.client.Get(fmt.Sprintf(fmt.Sprintf(historyURL, "appid=%s&lat=%f&lon=%f&start=%d&end=%d"), h.Key, location.Latitude, location.Longitude, hp.Start, hp.End))
+	response, err := h.client.Get(fmt.Sprintf(fmt.Sprintf(h.historyURL, "appid=%s&lat=%f&lon=%f&start=%d&end=%d"), h.Key, location.Latitude, location.Longitude, hp.Start, hp.End))
 	if err != nil {
 		return err
 	}

--- a/history_test.go
+++ b/history_test.go
@@ -108,6 +108,39 @@ func TestNewHistoryWithInvalidHttpClient(t *testing.T) {
 	}
 }
 
+// TestNewHistorylWithApiURL  will verify that a new instance of HisoricalWeatherData
+// is created with custom API url
+func TestNewHistoryWithApiURL(t *testing.T) {
+	c, err := NewHistorical("c", os.Getenv("OWM_API_KEY"), WithApiURL("https://ru.openweathermap.org/"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(c).String() != "*openweathermap.HistoricalWeatherData" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := "https://ru.openweathermap.org/data/2.5/history/%s"
+	got := c.historyURL
+	if got != expected {
+		t.Errorf("Expected historyURL %v, but got %v", expected, got)
+	}
+}
+
+// TestNewHistoryWithInvalidApiURL  will verify that returns an error with
+// invalid API url
+func TestNewHistoryWithInvalidApiURL(t *testing.T) {
+	c, err := NewHistorical("c", os.Getenv("OWM_API_KEY"), WithApiURL("somestring"))
+	if err == errInvalidApiURL {
+		t.Logf("Received expected invalid url error. message: %s", err.Error())
+	} else if err != nil {
+		t.Errorf("Expected %v, but got %v", errInvalidApiURL, err)
+	}
+	if c != nil {
+		t.Errorf("Expected nil, but got %v", c)
+	}
+}
+
 // TestHistoryByName
 func TestHistoryByName(t *testing.T) {
 	t.Parallel()

--- a/pollution.go
+++ b/pollution.go
@@ -63,7 +63,7 @@ func NewPollution(key string, options ...Option) (*Pollution, error) {
 // PollutionByParams gets the pollution data based on the given parameters
 func (p *Pollution) PollutionByParams(params *PollutionParameters) error {
 	url := fmt.Sprintf("%s%s,%s/%s.json?appid=%s",
-		pollutionURL,
+		p.pollutionURL,
 		strconv.FormatFloat(params.Location.Latitude, 'f', -1, 64),
 		strconv.FormatFloat(params.Location.Longitude, 'f', -1, 64),
 		params.Datetime,

--- a/pollution_test.go
+++ b/pollution_test.go
@@ -80,6 +80,39 @@ func TestNewPollutionWithInvalidHttpClient(t *testing.T) {
 	}
 }
 
+// TestNewPollutionWithApiURL  will verify that a new instance of PollutionWeatherData
+// is created with custom API url
+func TestNewPollutionWithApiURL(t *testing.T) {
+	c, err := NewPollution(os.Getenv("OWM_API_KEY"), WithApiURL("https://ru.openweathermap.org/"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(c).String() != "*openweathermap.Pollution" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := "https://ru.openweathermap.org/pollution/v1/co/"
+	got := c.pollutionURL
+	if got != expected {
+		t.Errorf("Expected pollutionURL %v, but got %v", expected, got)
+	}
+}
+
+// TestNewPollutionWithInvalidApiURL  will verify that returns an error with
+// invalid API url
+func TestNewPollutionWithInvalidApiURL(t *testing.T) {
+	c, err := NewPollution(os.Getenv("OWM_API_KEY"), WithApiURL("somestring"))
+	if err == errInvalidApiURL {
+		t.Logf("Received expected invalid url error. message: %s", err.Error())
+	} else if err != nil {
+		t.Errorf("Expected %v, but got %v", errInvalidApiURL, err)
+	}
+	if c != nil {
+		t.Errorf("Expected nil, but got %v", c)
+	}
+}
+
 func TestValidAlias(t *testing.T) {
 	t.Parallel()
 	testAliases := []string{"now", "then", "current"}

--- a/uv.go
+++ b/uv.go
@@ -48,7 +48,7 @@ func NewUV(key string, options ...Option) (*UV, error) {
 
 // Current gets the current UV data for the given coordinates
 func (u *UV) Current(coord *Coordinates) error {
-	response, err := u.client.Get(fmt.Sprintf("%suvi?lat=%f&lon=%f&appid=%s", uvURL, coord.Latitude, coord.Longitude, u.Key))
+	response, err := u.client.Get(fmt.Sprintf("%suvi?lat=%f&lon=%f&appid=%s", u.uvURL, coord.Latitude, coord.Longitude, u.Key))
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func (u *UV) Current(coord *Coordinates) error {
 
 // Historical gets the historical UV data for the coordinates and times
 func (u *UV) Historical(coord *Coordinates, start, end time.Time) error {
-	response, err := u.client.Get(fmt.Sprintf("%shistory?lat=%f&lon=%f&start=%d&end=%d&appid=%s", uvURL, coord.Latitude, coord.Longitude, start.Unix(), end.Unix(), u.Key))
+	response, err := u.client.Get(fmt.Sprintf("%shistory?lat=%f&lon=%f&start=%d&end=%d&appid=%s", u.uvURL, coord.Latitude, coord.Longitude, start.Unix(), end.Unix(), u.Key))
 	if err != nil {
 		return err
 	}
@@ -95,33 +95,33 @@ type UVIndexInfo struct {
 // UVData contains data in regards to UV index ranges, rankings, and steps for protection
 var UVData = []UVIndexInfo{
 	{
-		UVIndex: []float64{0, 2.9},
-		MGC:     "Green",
-		Risk:    "Low",
+		UVIndex:               []float64{0, 2.9},
+		MGC:                   "Green",
+		Risk:                  "Low",
 		RecommendedProtection: "Wear sunglasses on bright days; use sunscreen if there is snow on the ground, which reflects UV radiation, or if you have particularly fair skin.",
 	},
 	{
-		UVIndex: []float64{3, 5.9},
-		MGC:     "Yellow",
-		Risk:    "Moderate",
+		UVIndex:               []float64{3, 5.9},
+		MGC:                   "Yellow",
+		Risk:                  "Moderate",
 		RecommendedProtection: "Take precautions, such as covering up, if you will be outside. Stay in shade near midday when the sun is strongest.",
 	},
 	{
-		UVIndex: []float64{6, 7.9},
-		MGC:     "Orange",
-		Risk:    "High",
+		UVIndex:               []float64{6, 7.9},
+		MGC:                   "Orange",
+		Risk:                  "High",
 		RecommendedProtection: "Cover the body with sun protective clothing, use SPF 30+ sunscreen, wear a hat, reduce time in the sun within three hours of solar noon, and wear sunglasses.",
 	},
 	{
-		UVIndex: []float64{8, 10.9},
-		MGC:     "Red",
-		Risk:    "Very high",
+		UVIndex:               []float64{8, 10.9},
+		MGC:                   "Red",
+		Risk:                  "Very high",
 		RecommendedProtection: "Wear SPF 30+ sunscreen, a shirt, sunglasses, and a wide-brimmed hat. Do not stay in the sun for too long.",
 	},
 	{
-		UVIndex: []float64{11},
-		MGC:     "Violet",
-		Risk:    "Extreme",
+		UVIndex:               []float64{11},
+		MGC:                   "Violet",
+		Risk:                  "Extreme",
 		RecommendedProtection: "Take all precautions: Wear SPF 30+ sunscreen, a long-sleeved shirt and trousers, sunglasses, and a very broad hat. Avoid the sun within three hours of solar noon.",
 	},
 }

--- a/uv_test.go
+++ b/uv_test.go
@@ -85,6 +85,39 @@ func TestNewUVWithInvalidHttpClient(t *testing.T) {
 	}
 }
 
+// TestNewUVWithApiURL  will verify that a new instance of UVWeatherData
+// is created with custom API url
+func TestNewUVWithApiURL(t *testing.T) {
+	c, err := NewUV(os.Getenv("OWM_API_KEY"), WithApiURL("https://ru.openweathermap.org/"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if reflect.TypeOf(c).String() != "*openweathermap.UV" {
+		t.Error("incorrect data type returned")
+	}
+
+	expected := "https://ru.openweathermap.org/data/2.5/"
+	got := c.uvURL
+	if got != expected {
+		t.Errorf("Expected buvURL %v, but got %v", expected, got)
+	}
+}
+
+// TestNewUVWithInvalidApiURL  will verify that returns an error with
+// invalid API url
+func TestNewUVWithInvalidApiURL(t *testing.T) {
+	c, err := NewUV(os.Getenv("OWM_API_KEY"), WithApiURL("somestring"))
+	if err == errInvalidApiURL {
+		t.Logf("Received expected invalid url error. message: %s", err.Error())
+	} else if err != nil {
+		t.Errorf("Expected %v, but got %v", errInvalidApiURL, err)
+	}
+	if c != nil {
+		t.Errorf("Expected nil, but got %v", c)
+	}
+}
+
 // TestCurrentUV
 func TestCurrentUV(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
One of the IP addresses `api.openweathermap.org` is blocked in Russia.
To avoid errors, we use `ru.api.openweathermap.org`.

I added the ApiURL option.