### PR TITLE
Deprecate CurrentByZip, add CurrentByZipcode

### DIFF
--- a/current.go
+++ b/current.go
@@ -126,17 +126,28 @@ func (w *CurrentWeatherData) CurrentByID(id int) error {
 
 // CurrentByZip will provide the current weather for the
 // provided zip code.
+//
+// Deprecated: Use CurrentByZipcode instead.
 func (w *CurrentWeatherData) CurrentByZip(zip int, countryCode string) error {
-	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(baseURL, "appid=%s&zip=%d,%s&units=%s&lang=%s"), w.Key, zip, countryCode, w.Unit, w.Lang))
+	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(baseURL, "appid=%s&zip=%05d,%s&units=%s&lang=%s"), w.Key, zip, countryCode, w.Unit, w.Lang))
 	if err != nil {
 		return err
 	}
 	defer response.Body.Close()
-	if err = json.NewDecoder(response.Body).Decode(&w); err != nil {
+
+	return json.NewDecoder(response.Body).Decode(&w)
+}
+
+// CurrentByZipcode will provide the current weather for the
+// provided zip code.
+func (w *CurrentWeatherData) CurrentByZipcode(zip string, countryCode string) error {
+	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(baseURL, "appid=%s&zip=%s,%s&units=%s&lang=%s"), w.Key, zip, countryCode, w.Unit, w.Lang))
+	if err != nil {
 		return err
 	}
+	defer response.Body.Close()
 
-	return nil
+	return json.NewDecoder(response.Body).Decode(&w)
 }
 
 // CurrentByArea will provide the current weather for the

--- a/current_test.go
+++ b/current_test.go
@@ -237,6 +237,22 @@ func TestCurrentByZip(t *testing.T) {
 	if err := w.CurrentByZip(19125, "US"); err != nil {
 		t.Error(err)
 	}
+
+	// 02134 is a valid zip code in the US
+	if err := w.CurrentByZip(2134, "US"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestCurrentByZipcode(t *testing.T) {
+	w, err := NewCurrent("F", "EN", os.Getenv("OWM_API_KEY"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err := w.CurrentByZipcode("19125", "US"); err != nil {
+		t.Error(err)
+	}
 }
 
 func TestCurrentByArea(t *testing.T) {}


### PR DESCRIPTION
Zip codes in the USA can start with 0 - re: #88

In order to avoid making breaking changes, this 

1. Adds a `CurrentByZipcode` that uses a string for zip 
1. Changes `CurrentByZip` to use `%05d` to prefix zip int's with 0, such that `9123` gets prefixed with a 0 for the api and spits out `09123`
1. Adds a deprecation notice `Deprecated: Use CurrentByZipcode instead` 