### PR TITLE
Test against 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
-  - 1.5.4
-  - 1.6.2
+  - 1.13.x
 env:
   - GOARCH: amd64
   - GOARCH: 386


### PR DESCRIPTION
I noticed Travis is blowing up. You're currently testing against 1.5.4 and 1.6.2 but the coverage command you're trying to compile uses `context` which was added in 1.7

I upped the version you're testing against to 1.13 because that's the version stated in your go.mod

https://github.com/briandowns/openweathermap/blob/02925b28f09d0739270c36e579caf50827b1212e/go.mod#L3