### PR TITLE
Add API key error handling

### DIFF
--- a/current.go
+++ b/current.go
@@ -17,6 +17,7 @@ package openweathermap
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -86,6 +87,10 @@ func (w *CurrentWeatherData) CurrentByName(location string) error {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
+
 	if err := json.NewDecoder(response.Body).Decode(&w); err != nil {
 		return err
 	}
@@ -102,6 +107,10 @@ func (w *CurrentWeatherData) CurrentByCoordinates(location *Coordinates) error {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
+
 	if err = json.NewDecoder(response.Body).Decode(&w); err != nil {
 		return err
 	}
@@ -117,6 +126,10 @@ func (w *CurrentWeatherData) CurrentByID(id int) error {
 		return err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
 
 	if err = json.NewDecoder(response.Body).Decode(&w); err != nil {
 		return err
@@ -147,6 +160,10 @@ func (w *CurrentWeatherData) CurrentByZipcode(zip string, countryCode string) er
 		return err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
 
 	return json.NewDecoder(response.Body).Decode(&w)
 }

--- a/current_group.go
+++ b/current_group.go
@@ -3,6 +3,7 @@ package openweathermap
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 )
@@ -77,6 +78,10 @@ func (g *CurrentWeatherGroup) CurrentByIDs(ids ...int) error {
 		return err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
 
 	if err = json.NewDecoder(response.Body).Decode(&g); err != nil {
 		return err

--- a/history.go
+++ b/history.go
@@ -17,6 +17,7 @@ package openweathermap
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -99,6 +100,10 @@ func (h *HistoricalWeatherData) HistoryByName(location string) error {
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
+
 	if err = json.NewDecoder(response.Body).Decode(&h); err != nil {
 		return err
 	}
@@ -115,6 +120,10 @@ func (h *HistoricalWeatherData) HistoryByID(id int, hp ...*HistoricalParameters)
 		}
 		defer response.Body.Close()
 
+		if response.StatusCode == http.StatusUnauthorized {
+			return errInvalidKey
+		}
+
 		if err = json.NewDecoder(response.Body).Decode(&h); err != nil {
 			return err
 		}
@@ -125,6 +134,10 @@ func (h *HistoricalWeatherData) HistoryByID(id int, hp ...*HistoricalParameters)
 		return err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
 
 	if err = json.NewDecoder(response.Body).Decode(&h); err != nil {
 		return err
@@ -140,6 +153,10 @@ func (h *HistoricalWeatherData) HistoryByCoord(location *Coordinates, hp *Histor
 		return err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
 
 	if err = json.NewDecoder(response.Body).Decode(&h); err != nil {
 		return err

--- a/pollution.go
+++ b/pollution.go
@@ -3,6 +3,7 @@ package openweathermap
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 )
 
@@ -86,6 +87,10 @@ func (p *Pollution) PollutionByParams(params *PollutionParameters) error {
 		return err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
 
 	if err = json.NewDecoder(response.Body).Decode(&p); err != nil {
 		return err

--- a/uv.go
+++ b/uv.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -52,7 +53,12 @@ func (u *UV) Current(coord *Coordinates) error {
 	if err != nil {
 		return err
 	}
+
 	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
 
 	if err = json.NewDecoder(response.Body).Decode(&u); err != nil {
 		return err
@@ -67,7 +73,12 @@ func (u *UV) Historical(coord *Coordinates, start, end time.Time) error {
 	if err != nil {
 		return err
 	}
+
 	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusUnauthorized {
+		return errInvalidKey
+	}
 
 	if err = json.NewDecoder(response.Body).Decode(&u); err != nil {
 		return err


### PR DESCRIPTION
Hello,
Thank you for this helpful library!
Today, I found your library for a personal project but ran into an issue soon.
### Issue
- The current `API` key validation is not sufficient
- Thus, methods like `CurrentByCoordinates` or `CurrentByName` do *NOT* return an error if the provided `API` key is invalid

### Solution
- I added several `2-line` checks after the API request has been answered by the server.
- Because I only check the `http.Response.StatusCode`, my error-handling does *NOT* increase latency nor does it decrease performance 
- If the validation fails, the `errInvalidKey` error is returned
- This is *not* a new error type, it is already implemented

#### Code used for the checks
This code is executed *after* the response has been received but *before* the response-body is parsed.

```go
if response.StatusCode == http.StatusUnauthorized {
	return errInvalidKey
}
```

### Motivation
- For self-hostable projects which rely on this library, a user might enter an `API` key.
- However, the user would only get an indication that their key is invalid when they observe null-ish values in their results

### Summary
*Note*: I have not caused the broken integration check and tested my changes with the real `API`.
*Note 2*: I am aware that there is a `cod` inside the server's response

To sum it up, I added a small fix to a problem which bothers me and others.
I am also submitting this *PR* due to [#72].
I hope you understand my issue and are willing to merge this *PR*.
If this is not the case, feel free to contact me.