### PR TITLE
Switch OneCall to API 3.0

### DIFF
--- a/openweathermap.go
+++ b/openweathermap.go
@@ -35,7 +35,7 @@ var (
 var DataUnits = map[string]string{"C": "metric", "F": "imperial", "K": "internal"}
 var (
 	baseURL        = "https://api.openweathermap.org/data/2.5/weather?%s"
-	onecallURL     = "https://api.openweathermap.org/data/2.5/onecall?%s"
+	onecallURL     = "https://api.openweathermap.org/data/3.0/onecall?%s"
 	iconURL        = "https://openweathermap.org/img/w/%s"
 	groupURL       = "http://api.openweathermap.org/data/2.5/group?%s"
 	stationURL     = "https://api.openweathermap.org/data/2.5/station?id=%d"
@@ -185,8 +185,8 @@ type Clouds struct {
 	All int `json:"all"`
 }
 
-// 	return key
-// }
+//		return key
+//	}
 func setKey(key string) (string, error) {
 	if err := ValidAPIKey(key); err != nil {
 		return "", err


### PR DESCRIPTION
Switching from the discontinued 2.5 to using the 3.0 OneCall API works for a lot of calls. Needs more work to implement full range of features. Other 2.5 API's are still available.

Fixes #109 