### PR TITLE
Fix minor bug on onecall call with slash

### DIFF
--- a/onecall.go
+++ b/onecall.go
@@ -193,7 +193,7 @@ func (w *OneCallData) OneCallByCoordinates(location *Coordinates) error {
 // OneCallTimeMachine will provide the onecall timemachine weather with the
 // provided location coordinates and unix timestamp
 func (w *OneCallData) OneCallTimeMachine(location *Coordinates, datetime time.Time) error {
-	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(onecallURL, "timemachine?appid=%s&lat=%f&lon=%f&units=%s&lang=%s&dt=%d"), w.Key, location.Latitude, location.Longitude, w.Unit, w.Lang, datetime.Unix()))
+	response, err := w.client.Get(fmt.Sprintf(fmt.Sprintf(onecallURL, "/timemachine?appid=%s&lat=%f&lon=%f&units=%s&lang=%s&dt=%d"), w.Key, location.Latitude, location.Longitude, w.Unit, w.Lang, datetime.Unix()))
 	if err != nil {
 		return err
 	}

--- a/openweathermap.go
+++ b/openweathermap.go
@@ -35,7 +35,7 @@ var (
 var DataUnits = map[string]string{"C": "metric", "F": "imperial", "K": "internal"}
 var (
 	baseURL        = "https://api.openweathermap.org/data/2.5/weather?%s"
-	onecallURL     = "https://api.openweathermap.org/data/3.0/onecall/%s"
+	onecallURL     = "https://api.openweathermap.org/data/3.0/onecall%s"
 	iconURL        = "https://openweathermap.org/img/w/%s"
 	groupURL       = "http://api.openweathermap.org/data/2.5/group?%s"
 	stationURL     = "https://api.openweathermap.org/data/2.5/station?id=%d"


### PR DESCRIPTION
When upgrading to the latest version I noticed the onecall url to be broken.
Instead of introducing a separate url for the timemachine path I continued the route that was taken but simply fixed the overlooked bug. 